### PR TITLE
Fix the dependency updates

### DIFF
--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -31,8 +31,11 @@ jobs:
           # get the tool
           dotnet tool install --global dotnet-outdated-tool
 
-          # run the tool
-          dotnet outdated --upgrade AzDoExtensionNews\
+          # run the tool, skip the restore to prevent issues with the lock file
+          dotnet outdated --upgrade AzDoExtensionNews\ --no-restore  
+
+          # now try a restore, if it succeeds, we can still continue
+          dotnet restore AzDoExtensionNews/AzDoExtensionNews.sln --use-lock-file --force-evaluate
 
           # check for any updates with git porcelain
           if [[ -n $(git status --porcelain "Directory.Packages.props") ]]; then


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/upgrade-dependencies.yml` file to improve the dependency upgrade process by adding a restore step with specific options.

Improvements to dependency upgrade process:

* [`.github/workflows/upgrade-dependencies.yml`](diffhunk://#diff-eb27fef9445adeb0387001bd1d073e775dc7894a7343e65222fee6ac102847f5L34-R38): Modified the script to skip the restore step during the `dotnet outdated` command to prevent issues with the lock file, and added a subsequent restore step with specific options to ensure the process can continue if the restore succeeds.